### PR TITLE
Fixes duplicate folders creation when zipping with subfolders

### DIFF
--- a/Zip/ZipUtilities.swift
+++ b/Zip/ZipUtilities.swift
@@ -84,7 +84,6 @@ internal class ZipUtilities {
                 }
                 else {
                     let directoryContents = expandDirectoryFilePath(path)
-                    processedFilePaths.appendContentsOf(directoryContents)
                 }
             }
         }


### PR DESCRIPTION
When zipping subfolders they were added twice in the zip (in the root folder and in their correct position).
With this fix now folders with subfolders are created correctly.