### PR TITLE
Fix memory leak in unzip method

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -96,6 +96,9 @@ public class Zip {
         
         // Begin unzipping
         let zip = unzOpen64(path)
+        defer {
+            unzClose(zip)
+        }
         if unzGoToFirstFile(zip) != UNZ_OK {
             throw ZipError.UnzipFail
         }


### PR DESCRIPTION
Call defer to release the zip file resource after unzip is finished