### PR TITLE
Added to the Zip extension:

### DIFF
--- a/Zip/QuickZip.swift
+++ b/Zip/QuickZip.swift
@@ -92,6 +92,19 @@ extension Zip {
         try self.zipFiles(paths: paths, zipFilePath: destinationUrl, password: nil, progress: progress)
         return destinationUrl
     }
-    
+
+    /**
+     Quick zip files.
+     
+     - parameter paths: Array of NSURL filepaths.
+     - parameter destinationFileURL: Resulting zip-file URL.
+     
+     - throws: Error if zipping fails.
+     
+     - notes: Supports implicit progress composition
+    */
+    public class func quickZipFiles(_ paths: [URL], destinationFileURL: URL) throws {
+        try self.zipFiles(paths: paths, zipFilePath: destinationFileURL, password: nil, progress: nil)
+    }
     
 }

--- a/ZipTests/ZipTests.swift
+++ b/ZipTests/ZipTests.swift
@@ -152,6 +152,22 @@ class ZipTests: XCTestCase {
         }
     }
     
+    func testQuickZipDestinationURL() {
+        let imageURL1 = Bundle(for: ZipTests.self).url(forResource: "3crBXeO", withExtension: "gif")!
+        let imageURL2 = Bundle(for: ZipTests.self).url(forResource: "kYkLkPf", withExtension: "gif")!
+        let fileManager = FileManager.default
+        let cacheFolder = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0] as NSURL
+        let zipFilePath = cacheFolder.appendingPathComponent("archive.zip")
+        do {
+            try Zip.quickZipFiles([imageURL1, imageURL2], destinationFileURL: zipFilePath!)
+            XCTAssertTrue(fileManager.fileExists(atPath: zipFilePath!.path))
+        }
+        catch {
+            XCTFail()
+        }
+    }
+    
+    
     func testQuickZipFolder() {
         do {
             let fileManager = FileManager.default


### PR DESCRIPTION
public class func quickZipFiles(_ paths: [URL], destinationFileURL: URL) throws
Allowing to pass the destination file URL different from the standard Documents directory.
Unit test for the new function added to the test target.