### PR TITLE
Fix compilation problem with Xcode 9

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -166,8 +166,8 @@ public class Zip {
 
             let creationDate = Date()
 
-            let directoryAttributes = [FileAttributeKey.creationDate : creationDate,
-                                       FileAttributeKey.modificationDate : creationDate]
+            let directoryAttributes = [FileAttributeKey.creationDate.rawValue : creationDate,
+                                       FileAttributeKey.modificationDate.rawValue : creationDate]
 
             do {
                 if isDirectory {


### PR DESCRIPTION
Looks as if the .rawValue has been deleted unintentionally. Without the .rawValue it does not compile with Xcode 9.