### PR TITLE
Aligned Minizip module name with the official repository

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import minizip
+import Minizip
 
 /// Zip error type
 public enum ZipError: Error {

--- a/Zip/minizip/module.modulemap
+++ b/Zip/minizip/module.modulemap
@@ -1,4 +1,4 @@
-module minizip [system][extern_c] {
+module Minizip [system][extern_c] {
     header "unzip.h"
     header "zip.h"
     export *


### PR DESCRIPTION
* The module name of Minizip is `Minizip` and not `minizip` in the official repository ([dexman/Minizip](https://github.com/dexman/Minizip/blob/master/Minizip/iphoneos.modulemap#L12))
* I think this is causing the `no such module 'minizip'` issues that are reported in #86, #93, #59, #50, #134 and #43 
* By using the same name, it get's possible to build the Minizip framework independently (e.g. via Carthage) and still link against the correct library

I've also created a PR (https://github.com/dexman/Minizip/pull/2) on the Minizip wrapper repository because builds of the framework are failing right now. When this is merged, I would suggest creating a `Cartfile` which references the repository. Then it is enough to include `marmelroy/Zip` in the `Cartfile` and everything should just work.