### PR TITLE
Whitespaces handling for fileOutputHandler.

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -230,7 +230,8 @@ public class Zip {
             }
             
             if let fileHandler = fileOutputHandler,
-                let fileUrl = URL(string: fullPath) {
+                let encodedString = fullPath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                let fileUrl = URL(string: encodedString) {
                 fileHandler(fileUrl)
             }
             


### PR DESCRIPTION
File output handler have problem with whitespaces handling. When there are spaces in file name it dont't work at all. It can be solved with this simple fix.