### PR TITLE
URL's passed to closures should be file URL's

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -243,10 +243,8 @@ public class Zip {
                 progressHandler((currentPosition/totalSize))
             }
             
-            if let fileHandler = fileOutputHandler,
-                let encodedString = fullPath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                let fileUrl = URL(string: encodedString) {
-                fileHandler(fileUrl)
+            if let fileHandler = fileOutputHandler {
+                fileHandler(URL(fileURLWithPath: fullPath))
             }
             
             progressTracker.completedUnitCount = Int64(currentPosition)


### PR DESCRIPTION
If the URL's for unzipped files don't start with "file://" they can cause problems if
they are passed into other parts of iOS (eg share sheets).

Changing the URL constructor to generate file type URL's also correctly handles
paths with spaces. This eliminates the manual handling of these that's currently done.