### PR TITLE
Use @_implementationOnly imports for Minizip

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Minizip
+@_implementationOnly import Minizip
 
 /// Zip error type
 public enum ZipError: Error {


### PR DESCRIPTION
This allows users to use Zip with library evolution enabled, without
exposing minizip to consumers since nothing from that library is ever
exposed through the public API. This is a private Swift feature that
makes sure that Minizip is excluded from the generated swiftinterface
file. While there is some risk this could be removed / renamed in a
future Swift release, it is being used by SwiftSyntax and the new
swift-driver now, so it should be low risk. If it is ever removed I
believe there would be another solution to this problem.