### PR TITLE
Progress block being called twice with 1.0 fixed

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -366,9 +366,11 @@ public class Zip {
                     zipWriteInFileInZip(zip, buffer, UInt32(length))
                 }
                 
-                // Update progress handler
-                if let progressHandler = progress{
-                    progressHandler((currentPosition/totalSize))
+                // Update progress handler, only if progress is not 1, because
+                // if we call it when progress == 1, the user will receive
+                // a progress handler call with value 1.0 twice.
+                if let progressHandler = progress, currentPosition / totalSize != 1 {
+                    progressHandler(currentPosition/totalSize)
                 }
                 
                 progressTracker.completedUnitCount = Int64(currentPosition)


### PR DESCRIPTION
The zipping function of the framework had this bug that was calling the zip progress block twice with value 1.0 when finishing. 
This pull request fixed that