### PR TITLE
Suppress Build Error

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -350,7 +350,7 @@ public class Zip {
                     }
                 }
                 catch {}
-                let buffer = malloc(chunkSize)
+                let buffer = malloc(chunkSize)!
                 if let password = password, let fileName = fileName {
                     zipOpenNewFileInZip3(zip, fileName, &zipInfo, nil, 0, nil, 0, nil,Z_DEFLATED, compression.minizipCompression, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password, 0)
                 }


### PR DESCRIPTION
For the OSX build.

Creation of buffer needs to be force-unwrapped for Xcode 13 to build properly.