### PR TITLE
Fix compilation issue on Xcode 13

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -350,7 +350,9 @@ public class Zip {
                     }
                 }
                 catch {}
-                let buffer = malloc(chunkSize)
+                guard let buffer = malloc(chunkSize) else {
+                    fatalError("malloc returned null: Likely out of memory")
+                }
                 if let password = password, let fileName = fileName {
                     zipOpenNewFileInZip3(zip, fileName, &zipInfo, nil, 0, nil, 0, nil,Z_DEFLATED, compression.minizipCompression, 0, -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY, password, 0)
                 }


### PR DESCRIPTION
This fixes the build of Zip on Xcode 13.
Error:
<img width="680" alt="Screenshot 2021-10-14 at 12 26 54" src="https://user-images.githubusercontent.com/10621118/137308778-450b0443-c601-4df9-b0b6-4dbea800d228.png">

malloc returns an implicitly unwrapped optional, which seems to loose its "implicit" via the assignment.
`public func malloc(_ __size: Int) -> UnsafeMutableRawPointer!`
And `free` require unwrapped value: `func free(_: UnsafeMutableRawPointer)`
