### PR TITLE
Windows Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Carthage/Build
 .build/
 .swiftpm/
 Packages/
+
+# vim
+.*.sw?

--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -171,7 +171,7 @@ public class Zip {
             if (fileName[fileInfoSizeFileName] == "/".cString(using: String.Encoding.utf8)?.first || fileName[fileInfoSizeFileName] == "\\".cString(using: String.Encoding.utf8)?.first) {
                 isDirectory = true;
             }
-            free(fileName)
+            fileName.deallocate()
             if pathString.rangeOfCharacter(from: CharacterSet(charactersIn: "/\\")) != nil {
                 pathString = pathString.replacingOccurrences(of: "\\", with: "/")
             }

--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -158,7 +158,7 @@ public class Zip {
             let fileName = UnsafeMutablePointer<CChar>.allocate(capacity: fileNameSize)
             defer { fileName.deallocate() }
 
-            unzGetCurrentFileInfo64(zip, &fileInfo, fileName, UInt(fileNameSize), nil, 0, nil, 0)
+            unzGetCurrentFileInfo64(zip, &fileInfo, fileName, uLong(fileNameSize), nil, 0, nil, 0)
             fileName[Int(fileInfo.size_filename)] = 0
 
             var pathString = String(cString: fileName)

--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -156,6 +156,7 @@ public class Zip {
             let fileNameSize = Int(fileInfo.size_filename) + 1
             //let fileName = UnsafeMutablePointer<CChar>(allocatingCapacity: fileNameSize)
             let fileName = UnsafeMutablePointer<CChar>.allocate(capacity: fileNameSize)
+            defer { fileName.deallocate() }
 
             unzGetCurrentFileInfo64(zip, &fileInfo, fileName, UInt(fileNameSize), nil, 0, nil, 0)
             fileName[Int(fileInfo.size_filename)] = 0
@@ -171,7 +172,6 @@ public class Zip {
             if (fileName[fileInfoSizeFileName] == "/".cString(using: String.Encoding.utf8)?.first || fileName[fileInfoSizeFileName] == "\\".cString(using: String.Encoding.utf8)?.first) {
                 isDirectory = true;
             }
-            fileName.deallocate()
             if pathString.rangeOfCharacter(from: CharacterSet(charactersIn: "/\\")) != nil {
                 pathString = pathString.replacingOccurrences(of: "\\", with: "/")
             }

--- a/Zip/minizip/include/Minizip.h
+++ b/Zip/minizip/include/Minizip.h
@@ -9,8 +9,8 @@
 #ifndef Minizip_h
 #define Minizip_h
 
-#import "crypt.h"
-#import "unzip.h"
-#import "zip.h"
+#include "crypt.h"
+#include "unzip.h"
+#include "zip.h"
 
 #endif /* Minizip_h */

--- a/Zip/minizip/module/module.modulemap
+++ b/Zip/minizip/module/module.modulemap
@@ -1,5 +1,4 @@
 module Minizip [system][extern_c] {
     header "../include/Minizip.h"
-    link "z"
     export *
 }

--- a/ZipTests/ZipTests.swift
+++ b/ZipTests/ZipTests.swift
@@ -190,6 +190,8 @@ class ZipTests: XCTestCase {
         let foundPermissions = try FileManager.default.attributesOfItem(atPath: permission644.path)[.posixPermissions] as? Int
         #if os(Linux)
         let expectedPermissions = 0o664
+        #elseif os(Windows)
+        let expectedPermissions = 0o700
         #else
         let expectedPermissions = 0o644
         #endif
@@ -212,9 +214,15 @@ class ZipTests: XCTestCase {
         let attributes777 = try fileManager.attributesOfItem(atPath: permission777.path)
         let attributes600 = try fileManager.attributesOfItem(atPath: permission600.path)
         let attributes604 = try fileManager.attributesOfItem(atPath: permission604.path)
+        #if os(Windows)
+        XCTAssertEqual(attributes777[.posixPermissions] as? Int, 0o700)
+        XCTAssertEqual(attributes600[.posixPermissions] as? Int, 0o700)
+        XCTAssertEqual(attributes604[.posixPermissions] as? Int, 0o700)
+        #else
         XCTAssertEqual(attributes777[.posixPermissions] as? Int, 0o777)
         XCTAssertEqual(attributes600[.posixPermissions] as? Int, 0o600)
         XCTAssertEqual(attributes604[.posixPermissions] as? Int, 0o604)
+        #endif
     }
     
     func testQuickUnzipSubDir() throws {


### PR DESCRIPTION
There was a Swift forums thread that indicated that people wanted to use this package on Windows but it did not build due to the missing header.  In order to verify if it built on Windows, I built it locally.  This led to a series of changes which ultimately enabled the Windows support in the package.  I am opening the PR in case it is interesting for the project to enable Windows support.