### PR TITLE
Target correct macOS version.

### DIFF
--- a/Zip.podspec
+++ b/Zip.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '3.0'
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '12'
   s.requires_arc = true
 
   s.source_files = 'Zip/*.{swift,h}', 'Zip/minizip/*.{c,h}', 'Zip/minizip/include/*.{c,h}'


### PR DESCRIPTION
This lib uses URL which is only available from macOS 10.10.
Also it references libarclite which, when building with Xcode 15, is only available when targeting macOS 12.
So I bumped the deployment target.