### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Zip.addCustomFileExtension("file-extension-here")
 ### [Preferred] Setting up with [Swift Package Manager](https://swift.org/package-manager)
 To use Zip with Swift Package Manager, add it to your package's dependencies:
 ```swift
-.package(url: "https://github.com/marmelroy/Zip.git", .upToNextMinor(from: "2.1"))
+.package(url: "https://github.com/marmelroy/Zip.git", from: "2.1"))
 ```
 
 ### Setting up with [CocoaPods](http://cocoapods.org/?q=Zip)


### PR DESCRIPTION
replaced [deprecated](https://developer.apple.com/documentation/packagedescription/package/dependency/requirement-swift.enum/uptonextminor(from:)) upToNextMinor(from:)