### PR TITLE
Fix build failure in linux

### DIFF
--- a/Zip/Zip.swift
+++ b/Zip/Zip.swift
@@ -213,17 +213,17 @@ public class Zip {
             var writeBytes: UInt64 = 0
             var filePointer: UnsafeMutablePointer<FILE>?
             filePointer = fopen(fullPath, "wb")
-            while filePointer != nil {
-                let readBytes = unzReadCurrentFile(zip, &buffer, bufferSize)
-                if readBytes > 0 {
-                    guard fwrite(buffer, Int(readBytes), 1, filePointer) == 1 else {
-                        throw ZipError.unzipFail
+            var readBytes: Int32 = 0
+            if let fp = filePointer {
+                repeat {
+                    readBytes = unzReadCurrentFile(zip, &buffer, bufferSize)
+                    if readBytes > 0 {
+                        guard fwrite(buffer, Int(readBytes), 1, fp) == 1 else {
+                            throw ZipError.unzipFail
+                        }
+                        writeBytes += UInt64(readBytes)
                     }
-                    writeBytes += UInt64(readBytes)
-                }
-                else {
-                    break
-                }
+                } while readBytes != 0
             }
 
             if let fp = filePointer { fclose(fp) }


### PR DESCRIPTION
Fixes marmelroy/Zip#277

It seems that Swift is unwilling to implicitly unwrap the optional `filePointer: UnsafeMutablePointer?` when passing it to fwrite in linux, you can see this build failure in building a dependand library [here](https://github.com/csknns/wallet/actions/runs/14143909393/job/39628890252).

So I unwrap the filePointer before writing bytes. Also I improved the while loop that reads bytes from the zip file until there are no more, the condition before was `while filePointer != nil` that was always true, not the condition is that read method returns that zero bytes where read.